### PR TITLE
Add some targets for building and releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+ifndef VERSION
+$(error VERSION is not set)
+endif
+
+NAME = ktheory/cog-jq
+TAG = $(NAME):$(VERSION)
+
+build:
+	docker build -t $(TAG) .
+
+push: build
+	docker push $(TAG)
+
+release: push
+	git tag $(VERSION)
+	git push origin $(VERSION)


### PR DESCRIPTION
Includes targets for building and pushing docker images as well as tagging the current sha with a version number for a release.
