### PR TITLE
Conditionally emit json if output is json-y

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-RUN apk add --no-cache jq
+RUN apk add --no-cache jq bash
 
 ADD cog-jq /usr/bin/cog-jq
 

--- a/cog-jq
+++ b/cog-jq
@@ -1,6 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
 # Set the cog argument as the filter (default: '.')
-exec /usr/bin/jq "$COG_ARGV_0"
+RESULT=$(/usr/bin/jq "$COG_ARGV_0")
+
+# Emit JSON if the output sorta looks like JSON
+if [[ "$RESULT" == "{"* ]] || [[ "$RESULT" == "["* ]]; then
+  echo "JSON"
+fi
+
+# Emit results from running jq
+echo "$RESULT"

--- a/jq.yaml
+++ b/jq.yaml
@@ -1,12 +1,13 @@
 # Cog bundle config
 ---
-name: jq
-version: "0.1.0"
-description: Wrapper for jq, a lightweight and flexible JSON processor
 cog_bundle_version: 4
+
+name: jq
+version: "0.1.1"
+description: Wrapper for jq, a lightweight and flexible JSON processor
 docker:
   image: "ktheory/cog-jq"
-  tag: "v0.1.0"
+  tag: "v0.1.1"
 commands:
   jq:
     executable: /usr/bin/cog-jq


### PR DESCRIPTION
If the output from `jq` returns something that starts with a `[` or a `{` we emit `JSON` which tells Cog to parse the result as json. This allows you to use `jq` in the middle of a pipeline like any other command.

Also bumps the version to `v0.1.1`.
